### PR TITLE
再次修复Redis序列化报错

### DIFF
--- a/src/main/java/ltd/newbee/mall/config/CacheConfig.java
+++ b/src/main/java/ltd/newbee/mall/config/CacheConfig.java
@@ -1,9 +1,9 @@
 package ltd.newbee.mall.config;
 
-import com.alibaba.fastjson.support.spring.GenericFastJsonRedisSerializer;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
 import ltd.newbee.mall.common.Constants;
+import ltd.newbee.mall.redis.FastJsonRedisSerializer;
 import org.springframework.boot.autoconfigure.data.redis.LettuceClientConfigurationBuilderCustomizer;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
@@ -39,7 +39,7 @@ public class CacheConfig implements CachingConfigurer {
     }
 
     private RedisSerializer<Object> valueSerializer() {
-        return new GenericFastJsonRedisSerializer();
+        return new FastJsonRedisSerializer<>(Object.class);
     }
 
     /**

--- a/src/main/java/ltd/newbee/mall/redis/FastJsonRedisSerializer.java
+++ b/src/main/java/ltd/newbee/mall/redis/FastJsonRedisSerializer.java
@@ -1,0 +1,38 @@
+package ltd.newbee.mall.redis;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.Filter;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
+    private static final Filter AUTO_TYPE_FILTER = JSONReader.autoTypeFilter(
+            // 按需加上需要支持自动类型的类名前缀，范围越小越安全
+            "ltd.newbee.mall.entity",
+            "ltd.newbee.mall.controller.vo"
+    );
+
+    private Class<T> clazz;
+
+    public FastJsonRedisSerializer(Class<T> clazz) {
+        super();
+        this.clazz = clazz;
+    }
+
+    @Override
+    public byte[] serialize(T t) {
+        if (t == null) {
+            return new byte[0];
+        }
+        return JSON.toJSONBytes(t, JSONWriter.Feature.WriteClassName);
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) {
+        if (bytes == null || bytes.length <= 0) {
+            return null;
+        }
+        return JSON.parseObject(bytes, clazz, AUTO_TYPE_FILTER);
+    }
+}


### PR DESCRIPTION
之前修复的代码不是很完善，没有把要序列化的类加入过滤器，而且修复提交被覆盖了。
- 新增 FastJsonRedisSerializer 类，用于在 Redis 中对存储的对象进行序列化和反序列化。仅允许"ltd.newbee.mall.entity",
            "ltd.newbee.mall.controller.vo" 包中的类可以使用Autotype序列化。
